### PR TITLE
add deployment selector

### DIFF
--- a/stable/nextcloud/templates/deployment.yaml
+++ b/stable/nextcloud/templates/deployment.yaml
@@ -10,6 +10,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "nextcloud.fullname" . }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
mitigation of
```
Error: release nextcloud failed: Deployment.apps "nextcloud-nextcloud" is invalid: [spec.selector: Required value, spec.template.metadata.labels: Invalid value: map[string]string{"app":"nextcloud-nextcloud"}: `selector` does not match template `labels`]
```